### PR TITLE
chore: Add startup script for retransmitter

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,18 @@
+#! /bin/sh
+
+case "$1" in
+  start)
+    echo "Starting retransmitter"
+    start-stop-daemon -S -n retransmitter -a /usr/bin/retransmitter
+    ;;
+  stop)
+    echo "Stopping retransmitter"
+    start-stop-daemon -K -n retransmitter
+    ;;
+  *)
+    echo "Usage: $0 {start|stop}"
+    exit 1
+    ;;
+esac
+
+exit 0


### PR DESCRIPTION
Closing #7 
The code changes in this commit add a startup script for the retransmitter application. The script allows the user to start and stop the retransmitter using the commands "start" and "stop" respectively. It is also intended to start automatically on system startup